### PR TITLE
Typed request body

### DIFF
--- a/backend/src/middleware/validationMiddleware.ts
+++ b/backend/src/middleware/validationMiddleware.ts
@@ -3,12 +3,15 @@ import { Request, Response, NextFunction } from "express";
 import { z, ZodType } from "zod";
 import { StatusCodes } from "http-status-codes";
 
+interface TypedRequest<T> extends Request {
+  body: T;
+}
+
 export const validateData = <T>(schema: ZodType<T>) => {
-  return (req: Request, res: Response, next: NextFunction) => {
+  return (req: TypedRequest<T>, res: Response, next: NextFunction) => {
     const parsed = schema.safeParse(req.body);
 
     if (parsed.success) {
-      req.body = parsed.data as T;
       next();
     } else {
       console.log("Zod error", parsed.error);
@@ -22,4 +25,4 @@ export const validateData = <T>(schema: ZodType<T>) => {
       }
     }
   };
-}
+};

--- a/backend/src/routes/TripRouter.ts
+++ b/backend/src/routes/TripRouter.ts
@@ -4,8 +4,7 @@ import ActivityRouter from "./ActivityRouter";
 import { validateData } from "../middleware/validationMiddleware";
 import { tripCreateSchema } from "../schemas/tripSchema";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
-import { z } from "zod";
-import { StatusCodes } from 'http-status-codes'
+import { StatusCodes } from "http-status-codes";
 
 const router = express.Router();
 const prisma = new PrismaClient();
@@ -47,8 +46,7 @@ router.get("/:id", async (req, res) => {
 });
 
 // Create a new trip
-type TripCreateSchema = z.infer<typeof tripCreateSchema>;
-router.post("/", validateData<TripCreateSchema>(tripCreateSchema), async (req, res) => {
+router.post("/", validateData(tripCreateSchema), async (req, res) => {
   const { name, startDate, endDate, location } = req.body;
   try {
     const trip = await prisma.trip.create({


### PR DESCRIPTION
# Description

Add type hints for middleware.

The existing implementation has type `any` for `req.body`.

<img width="751" alt="image" src="https://github.com/trihoang0809/tourific/assets/74647679/7533481e-a1c2-4609-9784-910edbffb2ad">

After type hint,

<img width="771" alt="image" src="https://github.com/trihoang0809/tourific/assets/74647679/355c53b5-2047-44c9-b67d-f2f76a13e4c7">