### PR TITLE
Van/select img: Unsplash Integration to Set Trip Cover

### DIFF
--- a/backend/src/routes/TripRouter.ts
+++ b/backend/src/routes/TripRouter.ts
@@ -103,7 +103,7 @@ router.get("/:id", async (req, res) => {
 
 // Create a new trip
 router.post("/", validateData(tripCreateSchema), async (req, res) => {
-  const { name, startDate, endDate, location } = req.body;
+  const { name, startDate, endDate, location, image } = req.body;
   try {
     const trip = await prisma.trip.create({
       data: {
@@ -111,6 +111,7 @@ router.post("/", validateData(tripCreateSchema), async (req, res) => {
         startDate,
         endDate,
         location,
+        image,
       },
     });
     res.status(StatusCodes.CREATED).json(trip);
@@ -130,7 +131,7 @@ router.post("/", validateData(tripCreateSchema), async (req, res) => {
 router.put("/:id", validateData(tripCreateSchema), async (req, res) => {
   const { id } = req.params;
   console.log("id", id);
-  const { name, startDate, endDate, location } = req.body;
+  const { name, startDate, endDate, location, image } = req.body;
   console.log(req.body);
   const isValidID = await prisma.trip.findUnique({
     where: {
@@ -152,6 +153,7 @@ router.put("/:id", validateData(tripCreateSchema), async (req, res) => {
         startDate: startDate,
         endDate: endDate,
         location: location,
+        image,
       },
     });
     res.status(StatusCodes.OK).json(trip);

--- a/backend/src/schemas/tripSchema.ts
+++ b/backend/src/schemas/tripSchema.ts
@@ -24,8 +24,8 @@ export const tripCreateSchema = z.object({
       return data.address || data.citystate;
     }, "Please choose a destination"),
   image: z.object({
-    height: z.number(),
-    width: z.number(),
+    height: z.number().optional(),
+    width: z.number().optional(),
     url: z.string().url({ message: "Please use a URL" }).min(5),
   }),
 });

--- a/backend/src/schemas/tripSchema.ts
+++ b/backend/src/schemas/tripSchema.ts
@@ -9,9 +9,9 @@ export const tripCreateSchema = z.object({
     offset: true,
   }),
   endDate: z.string().datetime({
-      message: "Please select a date and time",
-      offset: true,
-    }),
+    message: "Please select a date and time",
+    offset: true,
+  }),
   location: z
     .object({
       address: z.string(),
@@ -23,4 +23,9 @@ export const tripCreateSchema = z.object({
     .refine((data) => {
       return data.address || data.citystate;
     }, "Please choose a destination"),
+  image: z.object({
+    height: z.number(),
+    width: z.number(),
+    url: z.string().url({ message: "Please use a URL" }).min(5),
+  }),
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@react-native-community/slider": "^4.5.2",
         "@react-native-menu/menu": "^1.0.0",
         "@reduxjs/toolkit": "^2.2.3",
+        "@rneui/themed": "^4.0.0-rc.8",
         "@tanstack/react-query": "^5.28.8",
         "expo": "^51.0.2",
         "expo-build-properties": "^0.12.1",
@@ -4387,8 +4388,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native-menu/menu": {
-      "version": "1.0.3",
-      "license": "MIT",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@react-native-menu/menu/-/menu-1.0.0.tgz",
+      "integrity": "sha512-DFtREX4I4w4Vh89ohnhvxzYtf4iPmJVILpTbpBOx0iDuVO94NFF1pqtULdlhzdqeJlyuE1FwTlBifziD9ZBx6g==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -4820,6 +4822,50 @@
       "license": "MIT",
       "dependencies": {
         "web-streams-polyfill": "^3.1.1"
+      }
+    },
+    "node_modules/@rneui/base": {
+      "version": "4.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rneui/base/-/base-4.0.0-rc.7.tgz",
+      "integrity": "sha512-dffzoYek3Qp+7wJzC42QjI/Fu1HOUNxFIR88t1laDrBV5QZQB55f+Vu5zLbC80/bh1b8fYtl63HTIWpORuA3Eg==",
+      "peer": true,
+      "dependencies": {
+        "@types/react-native-vector-icons": "^6.4.10",
+        "color": "^3.2.1",
+        "deepmerge": "^4.2.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-native-ratings": "^8.1.0",
+        "react-native-size-matters": "^0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/react-native-elements"
+      },
+      "peerDependencies": {
+        "react-native-safe-area-context": "^3.1.9 || ^4.0.0",
+        "react-native-vector-icons": ">7.0.0"
+      }
+    },
+    "node_modules/@rneui/base/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/@rneui/themed": {
+      "version": "4.0.0-rc.8",
+      "resolved": "https://registry.npmjs.org/@rneui/themed/-/themed-4.0.0-rc.8.tgz",
+      "integrity": "sha512-8L/XOrL9OK/r+/iBLvx63TbIdZOXF8SIjN9eArMYm6kRbMr8m4BitXllDN8nBhBsSPNYvL6EAgjk+i2MfY4sBA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/react-native-elements"
+      },
+      "peerDependencies": {
+        "@rneui/base": "4.0.0-rc.7"
       }
     },
     "node_modules/@rnx-kit/chromium-edge-launcher": {
@@ -5273,17 +5319,47 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
-      "devOptional": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.79",
-      "devOptional": true,
-      "license": "MIT",
+      "version": "18.2.69",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.69.tgz",
+      "integrity": "sha512-W1HOMUWY/1Yyw0ba5TkCV+oqynRjG7BnteBB+B7JmAK7iw3l2SW+VGOxL+akPweix6jk2NNJtyJKpn4TkpfK3Q==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/react-native": {
+      "version": "0.70.19",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.70.19.tgz",
+      "integrity": "sha512-c6WbyCgWTBgKKMESj/8b4w+zWcZSsCforson7UdXtXMecG3MxCinYi6ihhrHVPyUrVzORsvEzK8zg32z4pK6Sg==",
+      "peer": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-native-vector-icons": {
+      "version": "6.4.18",
+      "resolved": "https://registry.npmjs.org/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.18.tgz",
+      "integrity": "sha512-YGlNWb+k5laTBHd7+uZowB9DpIK3SXUneZqAiKQaj1jnJCZM0x71GDim5JCTMi4IFkhc9m8H/Gm28T5BjyivUw==",
+      "peer": true,
+      "dependencies": {
+        "@types/react": "*",
+        "@types/react-native": "^0.70"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -6803,8 +6879,8 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "devOptional": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/dag-map": {
       "version": "1.0.2",
@@ -8635,6 +8711,19 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -11806,6 +11895,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-size-matters": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.4.2.tgz",
+      "integrity": "sha512-DKE3f/sdcozd24oASgkP1iGg+YU3HoajRa5k3a4wkRzpiqREq8SGX12Y5zBgAt/8IivLQoTMYkyQu1/Giuy+zQ==",
+      "peer": true,
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-svg": {
       "version": "15.2.0",
       "license": "MIT",
@@ -13581,6 +13679,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unsplash-js": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/unsplash-js/-/unsplash-js-7.0.19.tgz",
+      "integrity": "sha512-j6qT2floy5Q2g2d939FJpwey1yw/GpQecFiSouyJtsHQPj3oqmqq3K4rI+GF8vU1zwGCT7ZwIGQd2dtCQLjYJw==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@react-native-community/slider": "^4.5.2",
     "@react-native-menu/menu": "^1.0.0",
     "@reduxjs/toolkit": "^2.2.3",
+    "@rneui/themed": "^4.0.0-rc.8",
     "@tanstack/react-query": "^5.28.8",
     "expo": "^51.0.2",
     "expo-build-properties": "^0.12.1",

--- a/frontend/src/app/trips/[id]/(tabs)/index.tsx
+++ b/frontend/src/app/trips/[id]/(tabs)/index.tsx
@@ -1,6 +1,5 @@
 import { View, Text, ScrollView, Image, TouchableOpacity, StyleSheet } from "react-native";
 import React, { useState, useEffect } from "react";
-import favicon from "@/assets/favicon.png";
 import { Link, Stack, router, useLocalSearchParams } from "expo-router";
 import { Feather, Ionicons, MaterialIcons } from "@expo/vector-icons";
 import { Dimensions } from "react-native";

--- a/frontend/src/app/trips/[id]/(tabs)/index.tsx
+++ b/frontend/src/app/trips/[id]/(tabs)/index.tsx
@@ -20,6 +20,7 @@ const TripDetailsScreen = () => {
     endDate: new Date(),
     startHour: 0,
     startMinute: 0,
+    image: { url: "" },
   });
 
   // more setting icon
@@ -97,8 +98,15 @@ const TripDetailsScreen = () => {
       <ScrollView style={{ width: width, height: height }}>
         <View>
           <Image
-            style={{ width: width, height: 200 }}
-            source={favicon} />
+            style={styles.image}
+            source={
+              trip.image && trip.image.url
+                ? { uri: trip.image.url }
+                : {
+                    uri: "https://images.unsplash.com/photo-1507608616759-54f48f0af0ee?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w2MTM3Mjd8MHwxfHNlYXJjaHw1fHxUcmF2ZWx8ZW58MHx8fHwxNzE2MTczNzc1fDA&ixlib=rb-4.0.3&q=80&w=400",
+                  }
+            }
+          />
         </View>
         <View
           style={{ borderTopLeftRadius: 30, borderTopRightRadius: 30, flex: 1, marginTop: -50 }}

--- a/frontend/src/app/trips/[id]/(tabs)/index.tsx
+++ b/frontend/src/app/trips/[id]/(tabs)/index.tsx
@@ -21,6 +21,8 @@ const TripDetailsScreen = () => {
     startMinute: 0,
     image: { url: "" },
   });
+  const defaultUri =
+    "https://images.unsplash.com/photo-1507608616759-54f48f0af0ee?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w2MTM3Mjd8MHwxfHNlYXJjaHw1fHxUcmF2ZWx8ZW58MHx8fHwxNzE2MTczNzc1fDA&ixlib=rb-4.0.3&q=80&w=400";
 
   // more setting icon
   const [modalEditVisible, setModalEditVisible] = useState(false);
@@ -102,7 +104,7 @@ const TripDetailsScreen = () => {
               trip.image && trip.image.url
                 ? { uri: trip.image.url }
                 : {
-                    uri: "https://images.unsplash.com/photo-1507608616759-54f48f0af0ee?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w2MTM3Mjd8MHwxfHNlYXJjaHw1fHxUcmF2ZWx8ZW58MHx8fHwxNzE2MTczNzc1fDA&ixlib=rb-4.0.3&q=80&w=400",
+                    uri: defaultUri,
                   }
             }
           />

--- a/frontend/src/app/trips/create.tsx
+++ b/frontend/src/app/trips/create.tsx
@@ -79,7 +79,10 @@ export default function CreateTripScreen() {
           hours: endTime.hour,
           minutes: endTime.minute,
         },
-        location: data.location
+        location: data.location,
+        image: {
+          url: savedPhoto,
+        }
       });
     } catch (error: any) {
       console.error("Error fetching trip:", error.toString());
@@ -109,6 +112,9 @@ export default function CreateTripScreen() {
         longitude: 0,
         radius: 0
       },
+      image: {
+        url: savedPhoto
+      }
     }
   );
 

--- a/frontend/src/components/PhotoAPI.tsx
+++ b/frontend/src/components/PhotoAPI.tsx
@@ -1,0 +1,162 @@
+import { useState, useEffect } from "react";
+import { SearchBar } from "@rneui/themed";
+import {
+  View,
+  Image,
+  Dimensions,
+  StyleSheet,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  Modal,
+  SafeAreaView,
+  Pressable,
+} from "react-native";
+import { router } from "expo-router";
+import Ionicons from "@expo/vector-icons/Ionicons";
+
+interface Result {
+  id: string;
+  urls: {
+    small: string;
+  };
+  user: {
+    name: string;
+    links: {
+      html: string;
+    };
+  };
+}
+interface PhotoAPIProps {
+  savePhoto: (photo: string) => void;
+  isVisible: boolean;
+  setIsVisible: (isVisible: boolean) => void;
+}
+
+const screenWidth = Dimensions.get("window").width;
+
+const PhotoAPI = ({ savePhoto, isVisible, setIsVisible }: PhotoAPIProps) => {
+  const UNSPLASH_API_KEY = process.env.EXPO_PUBLIC_UNSPLASH_API_KEY;
+  const [query, setQuery] = useState("scenery");
+  const [searchBarValue, setSearchBarValue] = useState("");
+  const updateQuery = (query: string) => {
+    setQuery(query);
+    setSearchBarValue(query);
+  };
+  const [results, setResults] = useState<Result[]>([]);
+
+  useEffect(() => {
+    const fetchImage = async (query: string) => {
+      try {
+        let response = await fetch(
+          `https://api.unsplash.com/search/photos?page=1&per_page=30&query=${query}&client_id=${UNSPLASH_API_KEY}`,
+        );
+        if (!response.ok) {
+          throw new Error("Failed to fetch images");
+        }
+        let data = await response.json();
+        console.log("First image fetched:", data.results[0]?.urls?.small);
+        setResults(data.results);
+      } catch (error: any) {
+        console.error("Error fetching trip:", error.toString());
+      }
+    };
+    fetchImage(query);
+  }, [query]);
+
+  return (
+    <Modal animationType="slide" visible={isVisible}>
+      <SafeAreaView style={{ flex: 1, backgroundColor: "transparent" }}>
+        <View style={styles.row}>
+          <Text style={styles.text}>Set cover</Text>
+          <Pressable
+            style={styles.closeButton}
+            onPress={() => setIsVisible(false)}
+          >
+            <Ionicons name="close" size={24} color="black" />
+          </Pressable>
+        </View>
+        <SearchBar
+          placeholder="Search an image..."
+          onChangeText={updateQuery}
+          value={searchBarValue}
+        />
+        <ScrollView>
+          <View style={styles.imageContainer}>
+            {results &&
+              results.map((result: Result) => {
+                return (
+                  <View>
+                    <TouchableOpacity
+                      onPress={() => {
+                        savePhoto(result.urls.small);
+                        setIsVisible(false);
+                      }}
+                    >
+                      <Image
+                        key={result.id}
+                        source={{
+                          uri: result.urls.small,
+                        }}
+                        style={styles.image}
+                      />
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      onPress={() => router.push(result.user.links.html)}
+                    >
+                      <Text numberOfLines={1} style={styles.author}>
+                        by {result.user.name}
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                );
+              })}
+          </View>
+          <Text style={styles.note}>Search to find more results.</Text>
+        </ScrollView>
+      </SafeAreaView>
+    </Modal>
+  );
+};
+
+export default PhotoAPI;
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 10,
+    paddingVertical: 15,
+  },
+  closeButton: {
+    position: "absolute",
+    right: 10,
+  },
+  text: {
+    textAlign: "center",
+    flex: 1,
+    fontWeight: "500",
+    fontSize: 18,
+  },
+  imageContainer: {
+    flexWrap: "wrap",
+    flexDirection: "row",
+    padding: 5,
+  },
+  image: {
+    margin: 5,
+    width: screenWidth / 2 - 15,
+    height: 100,
+    borderRadius: 5,
+  },
+  author: {
+    width: screenWidth / 2 - 15,
+    marginLeft: 5,
+    marginBottom: 5,
+    textDecorationLine: "underline",
+  },
+  note: {
+    alignSelf: "center",
+    fontSize: 15,
+  },
+});

--- a/frontend/src/components/TripCard.tsx
+++ b/frontend/src/components/TripCard.tsx
@@ -32,7 +32,7 @@ export const TripCard: React.FC<tripProps> = ({
   const [location, setLocation] = useState(trip.location.citystate);
   
   const noImage =
-    "https://st4.depositphotos.com/14953852/24787/v/450/depositphotos_247872612-stock-illustration-no-image-available-icon-vector.jpg";
+    "https://images.unsplash.com/photo-1507608616759-54f48f0af0ee?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w2MTM3Mjd8MHwxfHNlYXJjaHw1fHxUcmF2ZWx8ZW58MHx8fHwxNzE2MTczNzc1fDA&ixlib=rb-4.0.3&q=80&w=400";
 
   const defaultAvatar =
     "https://static1.colliderimages.com/wordpress/wp-content/uploads/2022/02/avatar-the-last-airbender-7-essential-episodes.jpg";

--- a/frontend/src/types/index.tsx
+++ b/frontend/src/types/index.tsx
@@ -15,6 +15,9 @@ export interface TripData {
     minutes: number,
   };
   location: MapData;
+  image: {
+    url: String;
+  }
 }
 
 export type MapData = {


### PR DESCRIPTION
# Description

<!-- Include a summary of your changes -->
This pull request introduces some updates to improve the user experience with the trip creation and viewing functionality. The key changes include:
- Added the ability to include images in the POST and PUT requests when creating or updating a trip.
- Integrated the Unsplash API to allow users to search and set cover images for their trips.
- Implemented a new component PhotoAPI for searching and selecting images. This can be reused in other screens.

## Issues

<!-- Reference the issue that you're working on (if exists) -->
<!-- When you references an issue, Github will automatically link the PR to Github -->
<!-- For example, "Resolve #1" links your PR to the first issue -->
<!-- For a full list of keywords, see here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Screenshots

https://github.com/trihoang0809/tourific/assets/87792873/3378b359-58fb-4d47-8af4-acaa322c960b

<!-- If you're making UI changes, please include screenshots and describe the expected user flow. -->

## Test

<!-- Describe how we can test your code -->
- Register for an API key from Unsplash: https://unsplash.com/oauth/applications
- Include in your .env file in frontend: `EXPO_PUBLIC_UNSPLASH_API_KEY={Your_Key}`
- Navigate to the trip creation page and create a new trip with an image.

## Possible Downsides

<!-- List anything we should be aware of -->
- I have yet to test the update cover when users update a trip. I will do so once #16 is merged.

## Additional Documentations
<!-- Describe any documentations or references that would be helpful for us to review your code -->
- [Unsplash API Documentation](https://unsplash.com/documentation)